### PR TITLE
Fix type safety warnings in server and client

### DIFF
--- a/JEasyCryptoClient/src/CryptoClient.java
+++ b/JEasyCryptoClient/src/CryptoClient.java
@@ -5,6 +5,8 @@ import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
+import java.util.HashMap;
+
 import org.json.simple.JSONObject;
 
 
@@ -137,38 +139,37 @@ public class CryptoClient implements Runnable, ReaderObserver {
 	}
 	
 	private void handleCapabilityRequest() throws IOException {
-		JSONObject request = new JSONObject();
-		request.put("id", requestId++);
-		request.put("operation", "capabilities");
-		String data = request.toJSONString();
+		String data = createRequest("capabilities", null, null);
 		DatagramPacket packet = new DatagramPacket(data.getBytes(), data.length(), serverAddr, serverPort);
 		socket.send(packet);
 	}
 	
 	private void handleEncryptRequest() throws IOException {
-		JSONObject request = new JSONObject();
-		request.put("id", requestId++);
-		request.put("operation", "encrypt");
 		String method = enterText("Give encryption method", true);
 		String text = enterText("Give text to encrypt", false);
-		request.put("method", method);
-		request.put("data", text);
-		String data = request.toJSONString();
+		String data = createRequest("encrypt", method, text);
 		DatagramPacket packet = new DatagramPacket(data.getBytes(), data.length(), serverAddr, serverPort);
 		socket.send(packet);
 	}
 	
 	private void handleDecryptRequest() throws IOException {
-		JSONObject request = new JSONObject();
-		request.put("id", requestId++);
-		request.put("operation", "decrypt");
 		String method = enterText("Give decryption method", true);
 		String text = enterText("Give text to decrypt", false);
-		request.put("method", method);
-		request.put("data", text);
-		String data = request.toJSONString();
+		String data = createRequest("decrypt", method, text);
 		DatagramPacket packet = new DatagramPacket(data.getBytes(), data.length(), serverAddr, serverPort);
 		socket.send(packet);
+	}
+
+	private String createRequest(String operation, String method, String text) {
+		HashMap<String, Object> requestMap = new HashMap<>();
+		requestMap.put("id", requestId++);
+		requestMap.put("operation", operation);
+		requestMap.put("method", method);
+		requestMap.put("data", text);
+		JSONObject requestJsonObject = new JSONObject(requestMap);
+		String requestString = requestJsonObject.toJSONString();
+
+		return requestString;
 	}
 	
 	private void handleQuitRequest() {

--- a/JEasyCryptoServer/src/CryptoServer.java
+++ b/JEasyCryptoServer/src/CryptoServer.java
@@ -3,6 +3,7 @@ import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.SocketException;
+import java.util.HashMap;
 
 import org.json.simple.JSONObject;
 import org.json.simple.parser.*;
@@ -101,11 +102,14 @@ public class CryptoServer implements Runnable {
 	} // end run()
 	
 	private String createResponse(String op, long id, EasyCryptoAPI.Result result) {
-		JSONObject toSend = new JSONObject();
-		toSend.put("id", id);
-		toSend.put("operation", op+"-response");
-		toSend.put("result", result.resultCode().ordinal());
-		toSend.put("data", result.result());
-		return toSend.toJSONString();
+		HashMap<String, Object> responseMap = new HashMap<>();
+		responseMap.put("id", id);
+		responseMap.put("operation", op + "-response");
+		responseMap.put("result", result.resultCode().ordinal());
+		responseMap.put("data", result.result());
+		JSONObject ResponseJsonObject = new JSONObject(responseMap);
+		String responseString = ResponseJsonObject.toJSONString();
+
+		return responseString;
 	}
 }


### PR DESCRIPTION
Instead of applying the fix in three different methods of the client I abstracted the functionality of creating the JSON string for the request to a helper method similarly to how the response is created on the server.

This will also make #7 easier as now there's only one place in the client where the change has to be done.

Fixes #16 