### PR TITLE
Add the possibility to provide the server port from the command line

### DIFF
--- a/JEasyCryptoServer/src/CryptoServer.java
+++ b/JEasyCryptoServer/src/CryptoServer.java
@@ -17,16 +17,23 @@ public class CryptoServer implements Runnable {
 	private DatagramSocket socket;
 	private byte[] incoming;
 	private boolean running = true;
-	
+	private static int port = 10000;
+
 	public static void main(String[] args) {
+        	if (args.length > 0) {
+        		try {
+				port = Integer.parseInt(args[0]);
+ 			} catch (NumberFormatException e) {
+				e.printStackTrace();
+ 			}
+                }
 		new CryptoServer().run();
 	}
 
 	public void run() {
-
 		try {
-			System.out.println("Launching CryptoServer...");
-			socket = new DatagramSocket(10000);
+			System.out.printf("Launching CryptoServer (listening on port : %s)...\n", port);
+			socket = new DatagramSocket(port);
 			System.out.printf("Local addess is : %s\n", socket.getLocalAddress().getHostAddress());
 			incoming = new byte[4096];
 			DatagramPacket packet = new DatagramPacket(incoming, incoming.length);

--- a/JEasyCryptoServer/src/CryptoServer.java
+++ b/JEasyCryptoServer/src/CryptoServer.java
@@ -24,7 +24,9 @@ public class CryptoServer implements Runnable {
         		try {
 				port = Integer.parseInt(args[0]);
  			} catch (NumberFormatException e) {
-				e.printStackTrace();
+				System.out.printf("Error: The port ('%s') you entered is not valid. Please provide a valid port.\n", args[0]);
+				System.out.println("Expected, e.g., './start.sh 3000'");
+				System.out.println("Falling back to the default port of '10000' instead.");
  			}
                 }
 		new CryptoServer().run();

--- a/JEasyCryptoServer/start.sh
+++ b/JEasyCryptoServer/start.sh
@@ -1,2 +1,2 @@
-java -cp ../EasyCryptoLib.jar:../json-simple-1.1.1.jar:bin:. CryptoServer
+java -cp ../EasyCryptoLib.jar:../json-simple-1.1.1.jar:bin:. CryptoServer $1
 


### PR DESCRIPTION
#6 This adds the possibility to provide the server port from the command line (e.g., ./start.sh 3000 starts the server listening on port 3000). If the port is not provided from the command line, port 10000 is used. 