### PR TITLE
#26 Added code formatting guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ You can also run the Client and Server on the same machine. When launching the c
 * Please also take a look at our [code of conduct](code-of-conduct.md), that acts as a guideline on how to communicate with people on this project. If you experienced a violation, do not hesitate to contact one of the maintainers.
 * We follow the [Google Java coding conventions](https://google.github.io/styleguide/javaguide.html), so please make sure that you adhere to them.
 * Please format your code.
-    *How to format code using IntelliJ IDEA or Eclipse: https://github.com/google/google-java-format
-    *How to format code using VSCode please see the file: VSCode_format_guide.md
+    * How to format code using IntelliJ IDEA or Eclipse: https://github.com/google/google-java-format
+    * How to format code using VSCode please see the file: VSCode_format_guide.md
 	
 This project considers the output of the [IntelliJ IDEA](https://www.jetbrains.com/idea/) IDE `Reformat Code` option as the gold standard.
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You can also run the Client and Server on the same machine. When launching the c
 * We follow the [Google Java coding conventions](https://google.github.io/styleguide/javaguide.html), so please make sure that you adhere to them.
 * Please format your code.
     * How to format code using [IntelliJ IDEA or Eclipse](https://github.com/google/google-java-format)
-    * How to format code using VSCode please see the file: VSCode_format_guide.md
+    * How to format code using VSCodium (or VSCODE) please see the [VSCode formatting guide](VSCode_format_guide.md)
     * Format code on any editor. Use the jar style approach described [here](https://github.com/google/google-java-format).
 
 ### Who do I talk to? ###

--- a/README.md
+++ b/README.md
@@ -51,8 +51,6 @@ You can also run the Client and Server on the same machine. When launching the c
 * Please format your code.
     * How to format code using IntelliJ IDEA or Eclipse: https://github.com/google/google-java-format
     * How to format code using VSCode please see the file: VSCode_format_guide.md
-	
-This project considers the output of the [IntelliJ IDEA](https://www.jetbrains.com/idea/) IDE `Reformat Code` option as the gold standard.
 
 ### Who do I talk to? ###
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ You can also run the Client and Server on the same machine. When launching the c
 * Please also take a look at our [code of conduct](code-of-conduct.md), that acts as a guideline on how to communicate with people on this project. If you experienced a violation, do not hesitate to contact one of the maintainers.
 * We follow the [Google Java coding conventions](https://google.github.io/styleguide/javaguide.html), so please make sure that you adhere to them.
 * Please format your code.
-    * How to format code using IntelliJ IDEA or Eclipse: https://github.com/google/google-java-format
+    * How to format code using [IntelliJ IDEA or Eclipse](https://github.com/google/google-java-format)
     * How to format code using VSCode please see the file: VSCode_format_guide.md
+    * Format code on any editor. Use the jar style approach described [here](https://github.com/google/google-java-format).
 
 ### Who do I talk to? ###
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,12 @@ You can also run the Client and Server on the same machine. When launching the c
 
 * To get started contributing to the project, see the [contributing guide](CONTRIBUTING.md).
 * Please also take a look at our [code of conduct](code-of-conduct.md), that acts as a guideline on how to communicate with people on this project. If you experienced a violation, do not hesitate to contact one of the maintainers.
-* We follow [these](https://google.github.io/styleguide/javaguide.html) Java coding conventions, so please make sure that you adhere to them.
-* Please format your code. This project considers the output of the [IntelliJ IDEA](https://www.jetbrains.com/idea/) IDE `Reformat Code` option as the gold standard.
+* We follow the [Google Java coding conventions](https://google.github.io/styleguide/javaguide.html), so please make sure that you adhere to them.
+* Please format your code.
+    *How to format code using IntelliJ IDEA or Eclipse: https://github.com/google/google-java-format
+    *How to format code using VSCode please see the file: VSCode_format_guide.md
+	
+This project considers the output of the [IntelliJ IDEA](https://www.jetbrains.com/idea/) IDE `Reformat Code` option as the gold standard.
 
 ### Who do I talk to? ###
 

--- a/VSCode_format_guide.md
+++ b/VSCode_format_guide.md
@@ -1,5 +1,5 @@
 # How to Format to Google Java Style using VSCODE:
-1. Install VSCode
+1. Install [VSCodium](https://github.com/VSCodium/vscodium) or [VSCODE](https://github.com/microsoft/vscode).
 2. Open any Java file with VSCODE
 3. Install the suggested Java plugins for VSCODE. It's called "Java Extension pack". (contains: Language Support for Java™ by Red Hat; Debugger for Java; Java Test Runner;Maven for Java; Java Dependency Viewer; Visual Studio IntelliCode)
 4. Go to settings. Search for "format". Scroll down until you find "settings.json" and open it and add the following lines:

--- a/VSCode_format_guide.md
+++ b/VSCode_format_guide.md
@@ -19,4 +19,4 @@
     "java.format.settings.url": "https://raw.githubusercontent.com/google/styleguide/gh-pages/eclipse-java-google-style.xml"
 }
 ```
-6. Go back to the java file and press shift + alt + F  to format the code.  (You may need to install a formatter at this stage)
+6. Go back to the java file and press **shift + alt + F**  to format the code.  (You may need to install a formatter at this stage)

--- a/VSCode_format_guide.md
+++ b/VSCode_format_guide.md
@@ -9,7 +9,7 @@
 "java.format.enabled": true,
 "java.format.settings.url": "https://raw.githubusercontent.com/google/styleguide/gh-pages/eclipse-java-google-style.xml"
 ```
-5. Now your 'settings.json' file should look something like this:
+5. Now your **settings.json** file should look something like this:
 ```
 {
     "html.format.enable": false,

--- a/VSCode_format_guide.md
+++ b/VSCode_format_guide.md
@@ -1,6 +1,6 @@
 # How to Format to Google Java Style using VSCODE:
 1. Install [VSCodium](https://github.com/VSCodium/vscodium) or [VSCODE](https://github.com/microsoft/vscode).
-2. Open any Java file with VSCODE
+2. Open any Java file with VSCodium (or VSCODE)
 3. Install these plugins from **Settings ** -> **Extensions**:
 * Language Support for Java(TM) by Red Hat
 * Visual Studio IntelliCode.
@@ -19,4 +19,4 @@
     "java.format.settings.url": "https://raw.githubusercontent.com/google/styleguide/gh-pages/eclipse-java-google-style.xml"
 }
 ```
-6. Go back to the java file and press **shift + alt + F**  to format the code.  (You may need to install a formatter at this stage)
+6. Go back to the java file and press **shift + alt + F**  to format the code.

--- a/VSCode_format_guide.md
+++ b/VSCode_format_guide.md
@@ -1,0 +1,20 @@
+# How to Format to Google Java Style using VSCODE:
+1. Install VSCode
+2. Open any Java file with VSCODE
+3. Install the suggested Java plugins for VSCODE. It's called "Java Extension pack". (contains: Language Support for Java™ by Red Hat; Debugger for Java; Java Test Runner;Maven for Java; Java Dependency Viewer; Visual Studio IntelliCode)
+4. Go to settings. Search for "format". Scroll down until you find "settings.json" and open it and add the following lines:
+
+"java.format.enabled": true,
+"java.format.settings.url": "https://raw.githubusercontent.com/google/styleguide/gh-pages/eclipse-java-google-style.xml"
+
+5. Now your 'settings.json' file should look something like this:
+
+{
+    "html.format.enable": false,
+    "editor.suggestSelection": "first",
+    "vsintellicode.modify.editor.suggestSelection": "automaticallyOverrodeDefaultValue",
+    "java.format.enabled": true,
+    "java.format.settings.url": "https://raw.githubusercontent.com/google/styleguide/gh-pages/eclipse-java-google-style.xml"
+}
+
+6. Go back to the java file and press shift + alt + F  to format the code.  (You may need to install a formatter at this stage)

--- a/VSCode_format_guide.md
+++ b/VSCode_format_guide.md
@@ -3,12 +3,12 @@
 2. Open any Java file with VSCODE
 3. Install the suggested Java plugins for VSCODE. It's called "Java Extension pack". (contains: Language Support for Java™ by Red Hat; Debugger for Java; Java Test Runner;Maven for Java; Java Dependency Viewer; Visual Studio IntelliCode)
 4. Go to settings. Search for "format". Scroll down until you find "settings.json" and open it and add the following lines:
-
+```
 "java.format.enabled": true,
 "java.format.settings.url": "https://raw.githubusercontent.com/google/styleguide/gh-pages/eclipse-java-google-style.xml"
-
+```
 5. Now your 'settings.json' file should look something like this:
-
+```
 {
     "html.format.enable": false,
     "editor.suggestSelection": "first",
@@ -16,5 +16,5 @@
     "java.format.enabled": true,
     "java.format.settings.url": "https://raw.githubusercontent.com/google/styleguide/gh-pages/eclipse-java-google-style.xml"
 }
-
+```
 6. Go back to the java file and press shift + alt + F  to format the code.  (You may need to install a formatter at this stage)

--- a/VSCode_format_guide.md
+++ b/VSCode_format_guide.md
@@ -1,7 +1,9 @@
 # How to Format to Google Java Style using VSCODE:
 1. Install [VSCodium](https://github.com/VSCodium/vscodium) or [VSCODE](https://github.com/microsoft/vscode).
 2. Open any Java file with VSCODE
-3. Install the suggested Java plugins for VSCODE. It's called "Java Extension pack". (contains: Language Support for Java™ by Red Hat; Debugger for Java; Java Test Runner;Maven for Java; Java Dependency Viewer; Visual Studio IntelliCode)
+3. Install these plugins from **Settings ** -> **Extensions**:
+* Language Support for Java(TM) by Red Hat
+* Visual Studio IntelliCode.
 4. Go to settings. Search for "format". Scroll down until you find "settings.json" and open it and add the following lines:
 ```
 "java.format.enabled": true,

--- a/VSCode_format_guide.md
+++ b/VSCode_format_guide.md
@@ -4,7 +4,7 @@
 3. Install these plugins from **Settings ** -> **Extensions**:
 * Language Support for Java(TM) by Red Hat
 * Visual Studio IntelliCode.
-4. Go to settings. Search for "format". Scroll down until you find "settings.json" and open it and add the following lines:
+4. Go to settings. Search for text: **format**. Scroll down until you find **settings.json** and open it and add the following lines:
 ```
 "java.format.enabled": true,
 "java.format.settings.url": "https://raw.githubusercontent.com/google/styleguide/gh-pages/eclipse-java-google-style.xml"

--- a/VSCode_format_guide.md
+++ b/VSCode_format_guide.md
@@ -1,7 +1,7 @@
 # How to Format to Google Java Style using VSCODE:
 1. Install [VSCodium](https://github.com/VSCodium/vscodium) or [VSCODE](https://github.com/microsoft/vscode).
 2. Open any Java file with VSCodium (or VSCODE)
-3. Install these plugins from **Settings ** -> **Extensions**:
+3. Install these plugins from **Settings** -> **Extensions**:
 * Language Support for Java(TM) by Red Hat
 * Visual Studio IntelliCode.
 4. Go to settings. Search for text: **format**. Scroll down until you find **settings.json** and open it and add the following lines:


### PR DESCRIPTION
Replaced formatting instructions regarding IntelliJ IDEA. By default IntelliJ IDEA reformat code did not follow Google Java Style correctly, when it comes to indentation.

Added two new methods to format the code: VSCODE and formatting via jar file.