### PR TITLE
Add makefile to ease building process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+all: lib client server
+
+# Builds the EasyCrypto libary
+lib:
+	mkdir -p JEasyCrypto/bin
+	javac JEasyCrypto/src/easycrypto/*.java -d JEasyCrypto/bin
+	cd JEasyCrypto/bin/ && jar cvf ../../EasyCryptoLib.jar easycrypto/*.class
+
+# Builds the JEasyCryptoServer
+client:
+	mkdir -p JEasyCryptoClient/bin
+	javac JEasyCryptoClient/src/*.java -classpath "json-20190722.jar:." -d JEasyCryptoClient/bin
+
+# Builds the JEasyCryptoServer
+server:
+	mkdir -p JEasyCryptoServer/bin
+	javac JEasyCryptoServer/src/*.java -classpath "EasyCryptoLib.jar:json-20190722.jar:." -d JEasyCryptoServer/bin
+
+# Remove built binaries
+clean:
+	rm -rf JEasyCryptoClient/bin \
+			JEasyCrypto/bin \
+			JEasyCryptoServer/bin \
+			EasyCryptoLib.jar


### PR DESCRIPTION
The building process of the JEasyCrypto is a bit redundant, so our group introduced makefile to ease the process. The makefile combines all build script into single file and therefore all the binaries can be built with single command `make` in project root.